### PR TITLE
[Feat] diet_main.html 식사 수정, 삭제 기능 뷰와 연결

### DIFF
--- a/analysis/views.py
+++ b/analysis/views.py
@@ -494,3 +494,22 @@ def analysis_nutrients(request):
     #나중에 프론트에서 diet_analysis.html 같은 템플릿 만들고 나면 아래 주석처리 해놓은 render 함수로 바꿔 사용해주세요!
     #return render(request, "analysis/nutrients_analysis.html", context)
     return JsonResponse(context, json_dumps_params={'ensure_ascii': False})
+
+
+#WHO 기준과 비교하기 뷰
+def analysis_WHO(request):
+    try:
+        #url에서 쿼리로 주어진 start_date, end_date
+        start_date = datetime.strptime(request.GET.get('start_date'), '%Y-%m-%d').date()
+        end_date = datetime.strptime(request.GET.get('end_date'), '%Y-%m-%d').date()
+    # 쿼리가 제대로 된 형식으로 주어지지 않았을 경우 예외처리
+    except Exception:
+        return HttpResponseBadRequest("날짜 형식이 잘못 되었습니다. YYYY-MM-DD 형식을 사용해 주세요.")
+    
+    # 분석 시작 날짜가 끝 날짜보다 뒤인 경우 예외처리
+    if start_date > end_date:
+        return HttpResponseBadRequest("분석 시작 날짜는 끝 날짜보다 이전이어야 합니다.")
+    
+    day_difference = (end_date - start_date).days + 1 #몇 일 차이인지 계산(양 끝 날짜 포함)
+
+    

--- a/diets/urls.py
+++ b/diets/urls.py
@@ -6,6 +6,6 @@ urlpatterns = [
     path('', views.diet_main),
     path('list/', views.diet_list),
     path('search/', views.diet_search),
-    path('<str:food_id>/', views.diet_create),
-    path('<str:diet_id>/', views.diet_update),
+    path('<uuid:diet_id>/', views.diet_update),
+    path('<uuid:food_id>/', views.diet_create),
 ]

--- a/diets/views.py
+++ b/diets/views.py
@@ -186,7 +186,6 @@ def diet_create(request, food_id):
 
 #식사 수정/삭제
 def diet_update(request, diet_id):
-    print(str(diet_id), "출력결과입니다!@~!~!!~@~!@~!~@!~@!~@!~@~!!~~~")
     #PATCH 메소드 분기
     if request.method == 'PATCH':
         diet = Diet.objects.get(diet_id = diet_id) #수정할 Diet 객체

--- a/diets/views.py
+++ b/diets/views.py
@@ -6,6 +6,7 @@ from django.contrib.auth.decorators import login_required
 from django.db.models import Case, When, Value, IntegerField
 from datetime import date
 import json
+from django.http import HttpResponse
 
 #유저 식사 리스트 전달
 @login_required
@@ -37,13 +38,13 @@ def diet_main(request):
             'data': []
         }
         #To FE: 템플릿 작업 시작하면 지금 return문 지우고 바로 아래에 주석처리 해둔 return문 채워서 사용해주세요!!!
-        #return render(request, '템플릿 이름.html', context)
-        return JsonResponse({
-            "user_id": str(user.id),
-            "year": year,
-            "month": month,
-            "data": []
-        }, json_dumps_params={'ensure_ascii': False})
+        return render(request, 'diets/diets_main.html', context)
+        # return JsonResponse({
+        #     "user_id": str(user.id),
+        #     "year": year,
+        #     "month": month,
+        #     "data": []
+        # }, json_dumps_params={'ensure_ascii': False})
 
     #--------------------여기부터 API 명세 형식에 맞게 데이터 구성해서 반환하는 부분---------------------------------
     current_date = diets[0].date #diets에서 가장 앞의 데이터(가장 빠른 데이터)를 가져와 현재 날짜로 설정
@@ -81,13 +82,13 @@ def diet_main(request):
     }
     
     #To FE: 템플릿 작업 시작하면 지금 return문 지우고 바로 아래에 주석처리 해둔 return문 채워서 사용해주세요!!!
-    #return render(request, '템플릿 이름.html', context)
-    return JsonResponse({
-        "user_id": user.id,
-        "year": year,
-        "month": month,
-        "data": data_list
-    }, json_dumps_params={'ensure_ascii': False})
+    return render(request, 'diets/diets_main.html', context)
+    # return JsonResponse({
+    #     "user_id": user.id,
+    #     "year": year,
+    #     "month": month,
+    #     "data": data_list
+    # }, json_dumps_params={'ensure_ascii': False})
 
 @login_required
 #유저가 최근 먹은 식품 리스트 전달
@@ -185,6 +186,7 @@ def diet_create(request, food_id):
 
 #식사 수정/삭제
 def diet_update(request, diet_id):
+    print(str(diet_id), "출력결과입니다!@~!~!!~@~!@~!~@!~@!~@!~@~!!~~~")
     #PATCH 메소드 분기
     if request.method == 'PATCH':
         diet = Diet.objects.get(diet_id = diet_id) #수정할 Diet 객체
@@ -205,7 +207,7 @@ def diet_update(request, diet_id):
     elif request.method == 'DELETE':
         diet = Diet.objects.get(diet_id=diet_id)
         diet.delete()
-        return redirect('/diets/') #식사 관리 메인 페이지로 redirect
+        return HttpResponse(status=204)
     
     #Http 메소드가 PATCH, DELETE 중 무엇도 아닌 경우
     return JsonResponse({'message': "예상치 못한 오류가 발생했습니다."}, status=404)

--- a/static/diets/diets_main.css
+++ b/static/diets/diets_main.css
@@ -1,0 +1,312 @@
+/* 식사기록페이지 스타일 */
+:root {
+    --main-color: rgba(86, 170, 178, 1);
+    --main-color-hover: rgba(94, 189, 198, 0.65);
+}
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    /* width:402px;
+    height: 874px; */
+}
+
+
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background-color: #2c2c2c;
+    line-height: 1.6;
+}
+
+.nav-bar {
+    
+    height: 62px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 20px;
+    color: white;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.nav-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.nav-right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+/* 페이지 제목 */
+.page-title {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    color: #2c2c2c;
+    font-size: 18px;
+    font-weight: 500;
+}
+
+/* 메인 컨테이너 */
+.meal-record-container {
+    max-width: 800px;
+    background-color: white;
+    border-radius: 12px;
+    padding: 30px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+    min-height: calc(100vh - 80px);
+    overflow-y: auto;
+}
+
+/* 월 네비게이션 */
+.month-navigation {
+    text-align: center;
+    font-size: 20px;
+    font-weight: bold;
+    margin-bottom: 20px;  /* 15px에서 20px로 조정 */
+    color: #333;
+}
+.month-separator {
+    height: 1px;
+    background-color: #eee;
+    margin-bottom: 15px;
+}
+/* 헤더 섹션 */
+.header-section {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+.header-separator {
+    height: 1px;
+    background-color: #eee;
+    margin-bottom: 20px;
+}
+
+.section-title {
+    display: flex;
+    align-items: center;
+    font-size: 18px;
+    font-weight: 600;
+    color: #333;
+}
+
+.cutlery-icon {
+    margin-right: 8px;
+    font-size: 20px;
+    color: #999;
+}
+
+/* 새 식사 버튼 */
+.add-meal-btn {
+    background-color: var(--main-color);
+    color: white;
+    border: none;
+    border-radius: 20px;
+    padding: 10px 20px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    transition: background-color 0.2s;
+}
+
+.add-meal-btn:hover {
+    background-color: #357abd;
+}
+
+.plus-icon {
+    font-size: 16px;
+    font-weight: bold;
+}
+
+/* 오늘의 식사 추가하기 */
+.add-today-meal {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    height: auto;
+    min-height: 105px;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px dashed rgba(94, 189, 198, 0.65);
+    border-radius: 12px;
+    background: rgba(86, 170, 178, 0.16);
+    padding: 40px 20px;
+    margin-bottom: 30px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.add-today-meal:hover {
+    background-color: #e3f2fd;
+    border-color:  rgba(94, 189, 198, 0.65);
+}
+
+.add-today-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    gap: 8px;
+}
+
+.plus-icon-large {
+    font-size: 32px;
+    color: var(--main-color);
+    font-weight: bold;
+}
+
+.add-today-text {
+    font-size: 16px;
+    color: var(--main-color);
+    font-weight: 500;
+}
+
+/* 일별 식사 기록 */
+.daily-meals {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+/* 일별 카드 */
+.day-card {
+    border-radius: 12px;  /* 16px에서 12px로 변경 - 더 둥글게 */
+    border: 1px solid #e0e0e0;  /* var(#E8E9EA)에서 #e0e0e0로 변경 */
+    background: #FFF;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);  /* 그림자 더 부드럽게 */
+    padding: 25px;  /* 20px에서 25px로 증가 - 더 여유롭게 */
+    margin-bottom: 20px;  /* 카드 간 간격 추가 */
+}
+
+/* 일 헤더 */
+.day-header {
+    font-size: 16px;
+    font-weight: 600;
+    color: #333;
+    margin-bottom: 20px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid #eee;
+}
+
+/* 식사 아이템 */
+.meal-item {
+    display: flex;
+    align-items: center;
+    padding: 15px 0;
+    border-bottom: 1px solid #f8f8f8;
+    flex-direction: row;
+}
+
+.meal-item:last-child {
+    border-bottom: none;
+}
+
+.meal-type {
+    font-size: 14px;
+    font-weight: 500;
+    color: #666;
+    min-width: 60px;
+    margin-right: 20px;
+    flex-shrink: 0;
+}
+
+.meal-content {
+    flex: 1;
+    font-size: 14px;
+    color: #333;
+    line-height: 1.5;
+    min-width: 0;
+}
+
+/* 식사 액션 버튼 */
+.meal-actions {
+    display: flex;
+    gap: 12px;
+    margin-left: 20px;
+}
+
+.edit-btn, .delete-btn {
+    background: none;
+    border: none;
+    padding: 6px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.edit-btn:hover, .delete-btn:hover {
+    background-color: #f5f5f5;
+}
+
+.edit-btn svg, .delete-btn svg {
+    display: block;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 768px) {
+    .meal-record-container {
+        padding: 20px;
+    }
+    
+    .header-section {
+        flex-direction: row;
+        gap: 15px;
+        align-items: center;
+    }
+    
+    .add-meal-btn {
+        align-self: auto;
+    }
+    
+    
+    .meal-actions {
+        margin-left: 10px;
+        align-self: flex-end;
+    }
+}
+
+@media (max-width: 480px) {
+    .page-title {
+        font-size: 16px;
+        top: 15px;
+        left: 15px;
+    }
+    
+    .meal-record-container {
+        padding: 15px;
+    }
+    
+    .month-navigation {
+        font-size: 18px;
+    }
+    
+    
+    
+    .plus-icon-large {
+        font-size: 28px;
+    }
+    
+    .add-today-text {
+        font-size: 14px;
+        color: var(—main-color);
+        font-weight: 500;
+        line-height: 1.2;
+    }
+} 

--- a/templates/diets/diets_main.html
+++ b/templates/diets/diets_main.html
@@ -52,8 +52,11 @@
                 class="edit-btn"
                 type="button"
                 data-diet-id="{{ diet.diet_id }}"
+                data-food-id="{{ diet.food_id }}"
                 data-food-name="{{ diet.food_name }}"
-                onclick="editMeal('{{ date.date }}','breakfast')"
+                data-date="{{ date.date }}"
+                data-meal="아침"
+                onclick="editMeal(this)"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -106,8 +109,11 @@
                 class="edit-btn"
                 type="button"
                 data-diet-id="{{ diet.diet_id }}"
+                data-food-id="{{ diet.food_id }}"
                 data-food-name="{{ diet.food_name }}"
-                onclick="editMeal('{{ date.date }}','lunch')"
+                data-date="{{ date.date }}"
+                data-meal="점심"
+                onclick="editMeal(this)"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -160,8 +166,11 @@
                 class="edit-btn"
                 type="button"
                 data-diet-id="{{ diet.diet_id }}"
+                data-food-id="{{ diet.food_id }}"
                 data-food-name="{{ diet.food_name }}"
-                onclick="editMeal('{{ date.date }}','dinner ')"
+                data-date="{{ date.date }}"
+                data-meal="저녁"
+                onclick="editMeal(this)"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -225,6 +234,48 @@
           el.closest(".meal-item")?.remove(); // 또는: location.reload();
         } else {
           alert(`삭제 실패 (${res.status})`);
+        }
+      }
+
+      async function editMeal(el) {
+        const dietId = el.dataset.dietId;
+        const curFood = el.dataset.foodId; // 문자열 (uuid 또는 int)
+        const curDate = el.dataset.date; // 'YYYY-MM-DD'
+        const curMeal = el.dataset.meal; // 'breakfast' | 'lunch' | 'dinner'
+
+        // 프롬프트로 새 값 입력(엔터 치면 기존값 유지)
+        const newFood =
+          prompt("food_id를 입력하세요 (생략=현재값 유지)", curFood) || curFood;
+        const newDate =
+          prompt(
+            "날짜를 YYYY-MM-DD로 입력하세요 (생략=현재값 유지)",
+            curDate
+          ) || curDate;
+        const newMeal =
+          prompt(
+            "끼니를 아침/점심/저녁 중 하나로 입력 (생략=현재값 유지)",
+            curMeal
+          ) || curMeal;
+
+        // PATCH 호출
+        const res = await fetch(`/diets/${dietId}/`, {
+          method: "PATCH",
+          headers: {
+            "X-CSRFToken": getCookie("csrftoken"),
+            "X-Requested-With": "XMLHttpRequest",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            food: newFood, // ✅ 뷰에서 Food.objects.get(food_id=data['food'])로 사용
+            date: newDate, // 'YYYY-MM-DD'
+            meal: newMeal, // 'breakfast'|'lunch'|'dinner'
+          }),
+        });
+
+        if (res.ok) {
+          location.reload(); // 간단히 새로고침
+        } else {
+          alert(`수정 실패 (${res.status})`);
         }
       }
     </script>

--- a/templates/diets/diets_main.html
+++ b/templates/diets/diets_main.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    {% load static %}
+    <link rel="stylesheet" href="{% static 'diets/diets_main.css' %}" />
+    {% csrf_token %}
+  </head>
+  <body>
+    <div class="page-title"></div>
+
+    <div class="meal-record-container">
+      <div class="nav-bar">
+        <div class="nav-left"></div>
+        <div class="nav-right"></div>
+      </div>
+      <!-- 월 네비게이션 -->
+      <div class="month-navigation">< 2025년 8월 ></div>
+      <!-- 헤더 섹션 -->
+      <div class="header-section">
+        <div class="section-title">
+          <span class="cutlery-icon">🍴</span>
+          식사기록
+        </div>
+        <button class="add-meal-btn">
+          <span class="plus-icon">+</span>
+          새 식사
+        </button>
+      </div>
+      <!-- 오늘의 식사 추가하기 -->
+      <div class="add-today-meal">
+        <div class="add-today-content">
+          <span class="plus-icon-large">+</span>
+          <span class="add-today-text">오늘의 식사 추가하기</span>
+        </div>
+      </div>
+
+      <!-- 일별 식사 기록 -->
+      <div class="daily-meals">
+        {% for date in data %}
+        <div class="day-card">
+          <div class="day-header">{{ date.date }}</div>
+
+          <!-- 아침 -->
+          {% if date.diets.breakfast %} {% for diet in date.diets.breakfast %}
+          <div class="meal-item">
+            <span class="meal-type">아침</span>
+            <span class="meal-content"> {{ diet.food_name }} </span>
+            <div class="meal-actions">
+              <button
+                class="edit-btn"
+                type="button"
+                data-diet-id="{{ diet.diet_id }}"
+                data-food-name="{{ diet.food_name }}"
+                onclick="editMeal('{{ date.date }}','breakfast')"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="15"
+                  height="15"
+                  viewBox="0 0 15 15"
+                  fill="none"
+                >
+                  <path
+                    d="M1 14.1993H3.82833L14.1993 3.82833L11.3707 1L1 11.371V14.1993Z"
+                    stroke="#B7B5B5"
+                    stroke-width="1.5"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </button>
+              <a
+                class="delete-btn"
+                data-diet-id="{{ diet.diet_id }}"
+                data-food-name="{{ diet.food_name }}"
+                onclick="deleteMeal(this)"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="14"
+                  height="16"
+                  viewBox="0 0 14 16"
+                  fill="none"
+                >
+                  <path
+                    d="M1 4.11111H12.9255M5.47205 7.22222V11.8889M8.45342 7.22222V11.8889M1.74534 4.11111L2.49068 13.4444C2.49068 13.857 2.64774 14.2527 2.92729 14.5444C3.20685 14.8361 3.58601 15 3.98137 15H9.9441C10.3395 15 10.7186 14.8361 10.9982 14.5444C11.2777 14.2527 11.4348 13.857 11.4348 13.4444L12.1801 4.11111M4.72671 4.11111V1.77778C4.72671 1.5715 4.80524 1.37367 4.94501 1.22781C5.08479 1.08194 5.27437 1 5.47205 1H8.45342C8.65109 1 8.84067 1.08194 8.98045 1.22781C9.12023 1.37367 9.19876 1.5715 9.19876 1.77778V4.11111"
+                    stroke="#B7B5B5"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </a>
+            </div>
+          </div>
+          {% endfor %} {% endif %}
+
+          <!-- 점심 -->
+          {% if date.diets.lunch %} {% for diet in date.diets.lunch %}
+          <div class="meal-item">
+            <span class="meal-type">점심</span>
+            <span class="meal-content"> {{ diet.food_name }} </span>
+            <div class="meal-actions">
+              <button
+                class="edit-btn"
+                type="button"
+                data-diet-id="{{ diet.diet_id }}"
+                data-food-name="{{ diet.food_name }}"
+                onclick="editMeal('{{ date.date }}','lunch')"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="15"
+                  height="15"
+                  viewBox="0 0 15 15"
+                  fill="none"
+                >
+                  <path
+                    d="M1 14.1993H3.82833L14.1993 3.82833L11.3707 1L1 11.371V14.1993Z"
+                    stroke="#B7B5B5"
+                    stroke-width="1.5"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </button>
+              <a
+                class="delete-btn"
+                data-diet-id="{{ diet.diet_id }}"
+                data-food-name="{{ diet.food_name }}"
+                onclick="deleteMeal(this)"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="14"
+                  height="16"
+                  viewBox="0 0 14 16"
+                  fill="none"
+                >
+                  <path
+                    d="M1 4.11111H12.9255M5.47205 7.22222V11.8889M8.45342 7.22222V11.8889M1.74534 4.11111L2.49068 13.4444C2.49068 13.857 2.64774 14.2527 2.92729 14.5444C3.20685 14.8361 3.58601 15 3.98137 15H9.9441C10.3395 15 10.7186 14.8361 10.9982 14.5444C11.2777 14.2527 11.4348 13.857 11.4348 13.4444L12.1801 4.11111M4.72671 4.11111V1.77778C4.72671 1.5715 4.80524 1.37367 4.94501 1.22781C5.08479 1.08194 5.27437 1 5.47205 1H8.45342C8.65109 1 8.84067 1.08194 8.98045 1.22781C9.12023 1.37367 9.19876 1.5715 9.19876 1.77778V4.11111"
+                    stroke="#B7B5B5"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </a>
+            </div>
+          </div>
+          {% endfor %}{% endif %}
+
+          <!-- 저녁 -->
+          {% if date.diets.dinner %} {% for diet in date.diets.dinner %}
+          <div class="meal-item">
+            <span class="meal-type">저녁</span>
+            <span class="meal-content"> {{ diet.food_name }} </span>
+            <div class="meal-actions">
+              <button
+                class="edit-btn"
+                type="button"
+                data-diet-id="{{ diet.diet_id }}"
+                data-food-name="{{ diet.food_name }}"
+                onclick="editMeal('{{ date.date }}','dinner ')"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="15"
+                  height="15"
+                  viewBox="0 0 15 15"
+                  fill="none"
+                >
+                  <path
+                    d="M1 14.1993H3.82833L14.1993 3.82833L11.3707 1L1 11.371V14.1993Z"
+                    stroke="#B7B5B5"
+                    stroke-width="1.5"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </button>
+              <a
+                class="delete-btn"
+                data-diet-id="{{ diet.diet_id }}"
+                data-food-name="{{ diet.food_name }}"
+                onclick="deleteMeal(this)"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="14"
+                  height="16"
+                  viewBox="0 0 14 16"
+                  fill="none"
+                >
+                  <path
+                    d="M1 4.11111H12.9255M5.47205 7.22222V11.8889M8.45342 7.22222V11.8889M1.74534 4.11111L2.49068 13.4444C2.49068 13.857 2.64774 14.2527 2.92729 14.5444C3.20685 14.8361 3.58601 15 3.98137 15H9.9441C10.3395 15 10.7186 14.8361 10.9982 14.5444C11.2777 14.2527 11.4348 13.857 11.4348 13.4444L12.1801 4.11111M4.72671 4.11111V1.77778C4.72671 1.5715 4.80524 1.37367 4.94501 1.22781C5.08479 1.08194 5.27437 1 5.47205 1H8.45342C8.65109 1 8.84067 1.08194 8.98045 1.22781C9.12023 1.37367 9.19876 1.5715 9.19876 1.77778V4.11111"
+                    stroke="#B7B5B5"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </a>
+            </div>
+          </div>
+          {% endfor %} {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    <script>
+      function getCookie(name) {
+        const v = `; ${document.cookie}`;
+        const p = v.split(`; ${name}=`);
+        if (p.length === 2) return p.pop().split(";").shift();
+      }
+
+      async function deleteMeal(el) {
+        const id = el.dataset.dietId;
+        console.log(id);
+        const res = await fetch(`/diets/${id}/`, {
+          method: "DELETE",
+          headers: { "X-CSRFToken": getCookie("csrftoken") },
+        });
+        if (res.status === 204) {
+          el.closest(".meal-item")?.remove(); // 또는: location.reload();
+        } else {
+          alert(`삭제 실패 (${res.status})`);
+        }
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## 📌 Summary
가원이의 SOS로 식사 수정, 삭제 뷰와 프론트를 연결했습니다.

## 📝 Describe your changes
- diet_update 뷰에서 기존 redirect 시키던 부분 HttpResponse 반환하도록 변경
- redirect 기능은 JS에서 reload 하도록 구현하였음
- 기존 uuid 필드를 url에서 str로 받고 있어서 uuid 필드로 명시함

## ✅ Check list
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally

## 🗣 Opinions 
- 나중에 새 식사를 만드는 html이 구현되면 기능 추가로 연결 필요
- 현재는 식사 수정 페이지가 없어서 프롬프트로 수정 사항을 입력 받지만, 추후 템플릿이 구현되고 나면 페이지 렌더링까지 구현 필요
