### PR TITLE
[Fix] nginx 파일 업로드 크기 제한 10MB로 설정

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -13,6 +13,9 @@ server {
     ssl_certificate /etc/letsencrypt/live/healthtant.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/healthtant.com/privkey.pem;
 
+    # 파일 업로드 크기 제한 (10MB)
+    client_max_body_size 10M;
+
     location /static/ {
         alias /app/staticfiles/;
     }


### PR DESCRIPTION
## 📌 Summary
nginx 파일 업로드 크기 제한 10MB로 설정
